### PR TITLE
fix: make NSNumber nonnull on iOS

### DIFF
--- a/android/src/main/java/io/swan/rnbrowser/RNSwanBrowserModuleImpl.java
+++ b/android/src/main/java/io/swan/rnbrowser/RNSwanBrowserModuleImpl.java
@@ -44,7 +44,7 @@ public class RNSwanBrowserModuleImpl {
     CustomTabColorSchemeParams.Builder paramsBuilder = new CustomTabColorSchemeParams.Builder();
     paramsBuilder.setNavigationBarColor(blackColor);
 
-    if (barTintColor != null) {
+    if (barTintColor != -1) {
       @ColorInt int intValue = barTintColor.intValue();
 
       paramsBuilder.setToolbarColor(intValue);

--- a/android/src/newarch/io/swan/rnbrowser/RNSwanBrowserModule.java
+++ b/android/src/newarch/io/swan/rnbrowser/RNSwanBrowserModule.java
@@ -42,9 +42,9 @@ public class RNSwanBrowserModule extends NativeRNSwanBrowserSpec implements Life
 
   @Override
   public void open(String url,
+                   Double barTintColor,
+                   Double controlTintColor,
                    @Nullable String dismissButtonStyle,
-                   @Nullable Double barTintColor,
-                   @Nullable Double controlTintColor,
                    Promise promise) {
     if (mBrowserVisible) {
       promise.reject("swan_browser_visible",

--- a/android/src/oldarch/io/swan/rnbrowser/RNSwanBrowserModule.java
+++ b/android/src/oldarch/io/swan/rnbrowser/RNSwanBrowserModule.java
@@ -44,9 +44,9 @@ public class RNSwanBrowserModule extends ReactContextBaseJavaModule implements L
 
   @ReactMethod
   public void open(String url,
+                   Double barTintColor,
+                   Double controlTintColor,
                    @Nullable String dismissButtonStyle,
-                   @Nullable Double barTintColor,
-                   @Nullable Double controlTintColor,
                    Promise promise) {
     if (mBrowserVisible) {
       promise.reject("swan_browser_visible",

--- a/ios/RNSwanBrowser.mm
+++ b/ios/RNSwanBrowser.mm
@@ -57,16 +57,16 @@ RCT_EXPORT_MODULE();
 }
 
 - (void)open:(NSString *)url
+        barTintColor:(nonnull NSNumber *)barTintColor
+        controlTintColor:(nonnull NSNumber *)controlTintColor
         dismissButtonStyle:(NSString *)dismissButtonStyle
-        barTintColor:(NSNumber *)barTintColor
-        controlTintColor:(NSNumber *)controlTintColor
         resolve:(RCTPromiseResolveBlock)resolve
         reject:(RCTPromiseRejectBlock)reject {
 #else
 RCT_EXPORT_METHOD(open:(NSString *)url
+                  barTintColor:(nonnull NSNumber *)barTintColor
+                  controlTintColor:(nonnull NSNumber *)controlTintColor
                   dismissButtonStyle:(NSString *)dismissButtonStyle
-                  barTintColor:(NSNumber *)barTintColor
-                  controlTintColor:(NSNumber *)controlTintColor
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
 #endif
@@ -89,10 +89,10 @@ RCT_EXPORT_METHOD(open:(NSString *)url
       [_safariVC setDismissButtonStyle:SFSafariViewControllerDismissButtonStyleDone];
     }
 
-    if (barTintColor != nil) {
+    if ([barTintColor intValue] != -1) {
       [_safariVC setPreferredBarTintColor:[RCTConvert UIColor:barTintColor]];
     }
-    if (controlTintColor != nil) {
+    if ([controlTintColor intValue] != -1) {
       [_safariVC setPreferredControlTintColor:[RCTConvert UIColor:controlTintColor]];
     }
 

--- a/src/NativeRNSwanBrowser.ts
+++ b/src/NativeRNSwanBrowser.ts
@@ -4,9 +4,9 @@ import { TurboModuleRegistry } from "react-native";
 export interface Spec extends TurboModule {
   open(
     url: string,
+    barTintColor: number,
+    controlTintColor: number,
     dismissButtonStyle?: string,
-    barTintColor?: number,
-    controlTintColor?: number,
   ): Promise<null>;
 
   close(): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,9 +34,9 @@ export const openBrowser = (url: string, options: Options): Promise<void> => {
 
   return NativeModule.open(
     url,
+    convertColorToNumber(barTintColor) || -1,
+    convertColorToNumber(controlTintColor) || -1,
     dismissButtonStyle,
-    convertColorToNumber(barTintColor),
-    convertColorToNumber(controlTintColor),
   ).then(() => {
     let deeplink: string | undefined;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

fixes: https://github.com/swan-io/react-native-browser/issues/4

There's probably a better way than setting `-1` to avoid this error, but I'm not sure what the right behavior to handle nullable NSNumber correctly on libraries.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to test it (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/src/App.tsx`)
